### PR TITLE
adds false to avoid overflow error

### DIFF
--- a/src/game/Update.cpp
+++ b/src/game/Update.cpp
@@ -472,7 +472,7 @@ void Game::resolveItemAction(char direction)
 void Game::pickUpItem() //player walks on a potion
 {
     Item **items = rooms[player.getCurrentRoom()]->getItems();
-    bool pickedUpItem;
+    bool pickedUpItem = false;
     Item* theItem;
     for (int i = 0; i < rooms[player.getCurrentRoom()]->getMaxItems(); i++)
     {


### PR DESCRIPTION
if this is not initially set to false, later when it is tested, it causes an exception because it is unset.